### PR TITLE
Removed remaining uses of `stmt`

### DIFF
--- a/src/random.nim
+++ b/src/random.nim
@@ -59,7 +59,7 @@ except OSError:
 #     proc shuffle*(arr: var RAContainer) {.inline.} =
 #       mersenneTwisterInst.shuffle(arr)
 
-macro makeAliases(): stmt {.immediate.} =
+macro makeAliases(): untyped =
   let body = parseStmt(staticRead("random/common.nim"))
   result = newStmtList()
 

--- a/src/random/urandom.nim
+++ b/src/random/urandom.nim
@@ -61,7 +61,7 @@ when defined(windows):
     if success == 0:
       raise newException(OSError, "Call to CryptAcquireContext failed")
 
-template urandomImpl(): stmt {.immediate.} =
+template urandomImpl(): untyped =
   when defined(windows):
     if cryptProv == 0:
       urandomInit()


### PR DESCRIPTION
Sorry, I noticed that two instances of `stmt` were left in the library. I did not notice them at first because they were in code paths that were not exercised by tests, but I noticed when I tried to use nim-random as a dependency.

Now I have looked up all uses and there are none left. My dependency [alea](https://github.com/unicredit/alea) also works with this version, so there should be no issues left. Sorry for the double PR